### PR TITLE
into() : Applying a Phrase to a TextView

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ CharSequence formatted = Phrase.from("Hi {first_name}, you are {age} years old."
   .format();
 ```
 
+Send your phrase straight into a TextView:
+
+```java
+Phrase.from("Welcome back {user}.")
+  .put("user", name)
+  .into(textView);
+```
+
 Comma-separated lists:
 ```
 CharSequence formattedList = ListPhrase.from(", ")

--- a/src/main/java/com/squareup/phrase/Phrase.java
+++ b/src/main/java/com/squareup/phrase/Phrase.java
@@ -15,11 +15,13 @@
  */
 package com.squareup.phrase;
 
+import android.support.annotation.NonNull;
 import android.app.Fragment;
 import android.content.Context;
 import android.content.res.Resources;
 import android.text.SpannableStringBuilder;
 import android.view.View;
+import android.widget.TextView;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -180,6 +182,14 @@ public final class Phrase {
       formatted = sb;
     }
     return formatted;
+  }
+
+  /** Apply the phrase to the target. */
+  public void into(@NonNull TextView target){
+    if (target == null) {
+      throw new IllegalArgumentException("Target must not be null.");
+    }
+    target.setText(format());
   }
 
   /**

--- a/src/test/java/com/squareup/phrase/PhraseTest.java
+++ b/src/test/java/com/squareup/phrase/PhraseTest.java
@@ -15,10 +15,15 @@
  */
 package com.squareup.phrase;
 
+import android.content.Context;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
+import android.widget.TextView;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
@@ -29,6 +34,8 @@ import static org.fest.assertions.api.Assertions.fail;
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
 public class PhraseTest {
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test public void emptyStringFormatsToItself() {
     assertThat(from("").format().toString()).isEqualTo("");
@@ -165,5 +172,21 @@ public class PhraseTest {
         "Abe").put("age", 20).format();
     assertThat(formatted.toString()).isEqualTo("Hello Abe, you are 20 years old.");
     assertThat(formatted).isInstanceOf(Spannable.class);
+  }
+
+  @Test public void testIntoSetsTargetText() {
+    Context context = Robolectric.application;
+    TextView textView = new TextView(context);
+
+    Phrase.from("Hello {user}!").put("user", "Eric").into(textView);
+    CharSequence actual = textView.getText().toString();
+
+    assertThat(actual.toString()).isEqualTo("Hello Eric!");
+  }
+
+  @Test public void testIntoNullFailsFast() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Target must not be null.");
+    Phrase.from("Hello {user}!").put("user", "Eric").into(null);
   }
 }


### PR DESCRIPTION
Allows setting text directly from the Phrase chain, similar to how Picasso does it.

Before:
```java
  CharSequence greeting = Phrase.from("Hello {user}!").put("user", "Quinn").format();
  greetingTextView.setText(greeting);
```

Now:
```java
  Phrase.from("Hello {user}!")
      .put("user", "Quinn")
      .into(greetingTextView);
```