### PR TITLE
API to disable span support

### DIFF
--- a/src/main/java/com/squareup/phrase/SimpleEditable.java
+++ b/src/main/java/com/squareup/phrase/SimpleEditable.java
@@ -1,0 +1,134 @@
+package com.squareup.phrase;
+
+import android.support.annotation.NonNull;
+import android.text.Editable;
+import android.text.InputFilter;
+
+import static java.util.regex.Matcher.quoteReplacement;
+import static java.util.regex.Pattern.quote;
+
+/**
+ * Provides basic support for replacing tokens with values without spans. This
+ * is used when {@link Phrase#setSpanSupportEnabled(boolean)} is turned off.
+ */
+final class SimpleEditable implements Editable {
+  private String text;
+
+  public SimpleEditable(CharSequence text) {
+    this(text.toString());
+  }
+
+  public SimpleEditable(String text) {
+    this.text = text;
+  }
+
+  @Override public Editable replace(int st, int en, CharSequence source, int start, int end) {
+    text = text.replaceFirst(quote(text.substring(st, en)), quoteReplacement(source.toString()));
+    return this;
+  }
+
+  @Override public Editable replace(int st, int en, CharSequence text) {
+    return replace(st, en, text, 0, text.length());
+  }
+
+  @Override public Editable insert(int where, CharSequence text, int start, int end) {
+    throw new UnsupportedOperationException("Not implemented.");
+  }
+
+  @Override public Editable insert(int where, CharSequence text) {
+    throw new UnsupportedOperationException("Not implemented.");
+  }
+
+  @Override public Editable delete(int st, int en) {
+    throw new UnsupportedOperationException("Not implemented.");
+  }
+
+  @Override public Editable append(CharSequence text) {
+    throw new UnsupportedOperationException("Not implemented.");
+  }
+
+  @Override public Editable append(CharSequence text, int start, int end) {
+    throw new UnsupportedOperationException("Not implemented.");
+  }
+
+  @Override public Editable append(char text) {
+    throw new UnsupportedOperationException("Not implemented.");
+  }
+
+  @Override public void clear() {
+  }
+
+  @Override public void clearSpans() {
+  }
+
+  @Override public void setFilters(InputFilter[] filters) {
+  }
+
+  @Override public InputFilter[] getFilters() {
+    return new InputFilter[0];
+  }
+
+  @Override public void getChars(int start, int end, char[] dest, int destoff) {
+  }
+
+  @Override public void setSpan(Object what, int start, int end, int flags) {
+  }
+
+  @Override public void removeSpan(Object what) {
+  }
+
+  @Override public <T> T[] getSpans(int start, int end, Class<T> type) {
+    return null;
+  }
+
+  @Override public int getSpanStart(Object tag) {
+    return 0;
+  }
+
+  @Override public int getSpanEnd(Object tag) {
+    return 0;
+  }
+
+  @Override public int getSpanFlags(Object tag) {
+    return 0;
+  }
+
+  @Override public int nextSpanTransition(int start, int limit, Class type) {
+    return 0;
+  }
+
+  @Override public int length() {
+    return text.length();
+  }
+
+  @Override public char charAt(int index) {
+    return text.charAt(index);
+  }
+
+  @Override public CharSequence subSequence(int start, int end) {
+    return text.subSequence(start, end);
+  }
+
+  @NonNull @Override public String toString() {
+    return text;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null) return false;
+
+    if (o.getClass() == String.class) {
+      return text.equals(o);
+    }
+
+    if (getClass() != o.getClass()) return false;
+
+    SimpleEditable that = (SimpleEditable) o;
+
+    return text.equals(that.text);
+  }
+
+  @Override public int hashCode() {
+    return text.hashCode();
+  }
+}

--- a/src/test/java/com/squareup/phrase/PhraseTest.java
+++ b/src/test/java/com/squareup/phrase/PhraseTest.java
@@ -19,7 +19,6 @@ import android.content.Context;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.widget.TextView;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -63,7 +62,7 @@ public class PhraseTest {
     try {
       from("{");
       fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException ignored) {
     }
   }
 
@@ -79,7 +78,7 @@ public class PhraseTest {
     try {
       from("hi { {age}.");
       fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException ignored) {
     }
   }
 
@@ -133,7 +132,7 @@ public class PhraseTest {
     try {
       gender.format();
       fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException ignored) {
     }
   }
 
@@ -141,7 +140,7 @@ public class PhraseTest {
     try {
       gender.put("bogusKey", "whatever");
       fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException ignored) {
     }
   }
 
@@ -149,7 +148,7 @@ public class PhraseTest {
     try {
       from("illegal {} pattern");
       fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException ignored) {
     }
   }
 
@@ -171,7 +170,7 @@ public class PhraseTest {
     try {
       from("{_foo}");
       fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException ignored) {
     }
   }
 


### PR DESCRIPTION
This mode unlocks the ability for consumers to disable span support. This enables writing pure unit tests that do not depend on `SpannableStringBuilder` which otherwise would require Robolectric to run and make the tests much much slower.

Fixed all warnings too.

@loganj  @ChrisRenke @rjrjr 
