### PR TITLE
More clear error messages for invalid characters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ android:
     - extra-android-m2repository
   licenses:
     - android-sdk-license-5be876d5
+    - android-sdk-license-c81a61d9
 
 jdk:
   - oraclejdk7

--- a/src/main/java/com/squareup/phrase/Phrase.java
+++ b/src/main/java/com/squareup/phrase/Phrase.java
@@ -259,7 +259,7 @@ public final class Phrase {
         return key(prev);
       } else {
         throw new IllegalArgumentException(
-            "Unexpected character '" + nextChar + "'; expected key.");
+            "Unexpected first character '" + nextChar + "'; must be lower case a-z.");
       }
     }
     return text(prev);
@@ -280,7 +280,8 @@ public final class Phrase {
 
     // Consume the closing '}'.
     if (curChar != '}') {
-      throw new IllegalArgumentException("Missing closing brace: }");
+      throw new IllegalArgumentException("Unexpected character '" + curChar
+          + "'; expecting lower case a-z, '_', or '}'");
     }
     consume();
 

--- a/src/test/java/com/squareup/phrase/PhraseTest.java
+++ b/src/test/java/com/squareup/phrase/PhraseTest.java
@@ -116,6 +116,16 @@ public class PhraseTest {
         .isEqualTo("Hello Eric");
   }
 
+  @Test public void putFailUppercaseNotAllowedMiddle() {
+    try{
+      from("Hello {aName}").putOptional("Name", "Eric").format();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage()) //
+          .isEqualTo("Unexpected character 'N'; expecting lower case a-z, '_', or '}'");
+    }
+  }
+
   private Phrase gender = from("{gender}");
 
   @Test
@@ -143,11 +153,12 @@ public class PhraseTest {
     }
   }
 
-  @Test public void illegalTokenCharactersFailFast() {
+  @Test public void illegalStartOfTokenCharactersFailFast() {
     try {
       from("blah {NoUppercaseAllowed}");
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage()).isEqualTo("Unexpected first character 'N'; must be lower case a-z.");
     }
   }
 


### PR DESCRIPTION
Tweaks invalid start- and end-of-token messages for clarity.

Inspired by #33, fixes #32 and fixes #34, probably #29 as well.