### PR TITLE
Update license and remove jdk7 to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ android:
   licenses:
     - android-sdk-license-5be876d5
     - android-sdk-license-c81a61d9
+    - android-sdk-license-2742d1c5
 
 jdk:
-  - oraclejdk7
   - oraclejdk8
 
 script:


### PR DESCRIPTION
Oracle JDK 7 no longer available; openJDK7 is missing an EC crypto
provider needed to download gradle plugins, so I just removed the 7
compiler. We could pursue workarounds but they're a bit messy, see
https://github.com/uber-java/tally/blob/2cea75ecc2f896dfd5e32b94bff71f211c8bde56/ci/before_install.sh#L6-L12

and gradle/gradle#2421